### PR TITLE
Assume the working directory if no arguments passed

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,34 @@
+package main
+
+import "testing"
+
+var tests = []struct {
+	wd   string
+	want string
+}{
+	{"/Users/kevin/src/github.com/davecheney/prdeps", "github.com/davecheney/prdeps"},
+	{"/Users/kevin/src", ""},
+	{"/Users/kevin/src/1", "1"},
+	{"/Users/kevin", ""},
+	{"/Users/kevin/var", ""},
+	{"/Users/kevin/var/tmp/foo", ""},
+	{"/Users/blah/src/github.com/davecheney/prdeps", ""},
+	{"/", ""},
+	{"", ""},
+	{"/Users/blah", ""},
+}
+
+func TestGetGoSubpath(t *testing.T) {
+	for _, tt := range tests {
+		got, err := getGoSubpath("/Users/kevin/src", tt.wd)
+		if err == nil && got == "" {
+			t.Errorf("getGoSubpath(%q, %q): want an error, got none", tt.wd, got)
+		}
+		if err != nil && got != "" {
+			t.Errorf("getGoSubpath(%q, %q): want a result, got an error", tt.wd, got)
+		}
+		if got != tt.want {
+			t.Errorf("getGoSubpath(%q, %q): got %t, want %t", "/Users/kevin/src", tt.wd, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Frequently when using prdeps, I want to check the package in the
working directory. However I still have to type it out manually for
prdeps to recognize it.

If a user does not pass any arguments to prdeps, assume they want
to evaluate the current working directory. If you are not in the
GOPATH, we return an error. Add some tests to double check that we are
correctly identifying directories in the GOPATH.